### PR TITLE
NE-33: Add Static Analysis Build to HAL

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
-# Strict clang-tidy configuration for production C code
-# Focuses on MISRA C compliance and embedded systems best practices
+# Production-grade clang-tidy configuration for embedded C projects
+# Focuses on MISRA C compliance, safety-critical requirements, and embedded systems best practices
 
 Checks: >
   bugprone-*,
@@ -17,6 +17,7 @@ Checks: >
   cert-msc30-c,
   cert-msc32-c,
   cert-pos44-c,
+  cert-sig30-c,
   cert-str31-c,
   cert-str32-c,
   cert-str34-c,
@@ -32,32 +33,20 @@ Checks: >
   misc-misplaced-const,
   misc-redundant-expression,
   misc-static-assert,
-  misc-throw-by-value-catch-by-reference,
-  misc-unconventional-assign-operator,
-  misc-uniqueptr-reset-release,
   misc-unused-alias-decls,
   misc-unused-parameters,
-  misc-unused-using-decls,
   performance-faster-string-find,
-  performance-for-range-copy,
   performance-implicit-conversion-in-loop,
   performance-inefficient-algorithm,
   performance-inefficient-string-concatenation,
-  performance-inefficient-vector-operation,
-  performance-move-const-arg,
-  performance-move-constructor-init,
-  performance-noexcept-move-constructor,
-  performance-trivially-destructible,
   performance-type-promotion-in-math-fn,
   performance-unnecessary-copy-initialization,
-  performance-unnecessary-value-param,
   portability-restrict-system-includes,
   portability-simd-intrinsics,
   readability-avoid-const-params-in-decls,
   readability-braces-around-statements,
   readability-const-return-type,
   readability-delete-null-pointer,
-  readability-deleted-default,
   readability-else-after-return,
   readability-function-size,
   readability-identifier-naming,
@@ -73,7 +62,6 @@ Checks: >
   readability-redundant-control-flow,
   readability-redundant-declaration,
   readability-redundant-function-ptr-dereference,
-  readability-redundant-smartptr-get,
   readability-redundant-string-cstr,
   readability-redundant-string-init,
   readability-simplify-boolean-expr,
@@ -83,16 +71,27 @@ Checks: >
   readability-string-compare,
   readability-uppercase-literal-suffix,
   -bugprone-easily-swappable-parameters,
-  -bugprone-macro-parentheses,
-  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
-  -misc-unused-parameters
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+  -mic-unused-parameters
 
-# Exclude vendor SDK and external dependencies
-# HeaderFilterRegex: '^(?!.*(gtest|gmock|third_party|build/_deps|\.conan|/sdk/)).*platforms/.*/hal/.*\.(h|c)$'
-HeaderFilterRegex: '.*(hal_interface|platforms/stm32f446re/hal)/.*\.(h|hpp)$'
+# Make critical safety issues into build-breaking errors
+WarningsAsErrors: >
+  clang-analyzer-core.NullDereference,
+  clang-analyzer-core.uninitialized.*,
+  clang-analyzer-core.DivideZero,
+  clang-analyzer-core.NonNullParamChecker,
+  cert-err33-c,
+  cert-err34-c,
+  bugprone-sizeof-expression,
+  bugprone-suspicious-memory-comparison,
+  bugprone-infinite-loop,
+  bugprone-macro-parentheses
+
+# Target embedded C code, exclude vendor SDK and external dependencies
+HeaderFilterRegex: '.*(hal_interface|platforms/stm32f446re/hal)/.*\.(h|c)$'
 
 CheckOptions:
-  # MISRA-style naming conventions
+  # MISRA C-style naming conventions for embedded systems
   - key: readability-identifier-naming.FunctionCase
     value: lower_case
   - key: readability-identifier-naming.VariableCase
@@ -110,7 +109,7 @@ CheckOptions:
   - key: readability-identifier-naming.MacroCase
     value: UPPER_CASE
   - key: readability-identifier-naming.EnumCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.EnumConstantCase
     value: UPPER_CASE
   - key: readability-identifier-naming.StructCase
@@ -120,7 +119,7 @@ CheckOptions:
   - key: readability-identifier-naming.UnionCase
     value: lower_case
 
-  # Function and complexity limits (MISRA-inspired)
+  # Strict function complexity limits for embedded safety
   - key: readability-function-size.LineThreshold
     value: '50'
   - key: readability-function-size.StatementThreshold
@@ -134,22 +133,22 @@ CheckOptions:
   - key: readability-function-size.VariableThreshold
     value: '10'
 
-  # Magic numbers (strict for embedded)
+  # Conservative magic numbers policy for embedded C
   - key: readability-magic-numbers.IgnoredIntegerValues
     value: '0;1;2;-1'
   - key: readability-magic-numbers.IgnoredFloatingPointValues
     value: '0.0;1.0;-1.0'
 
-  # Bracing style
+  # Enforce braces for all control statements (safety-critical requirement)
   - key: readability-braces-around-statements.ShortStatementLines
     value: '0'
 
-  # Implicit conversions
+  # Strict implicit conversion rules for embedded C
   - key: readability-implicit-bool-conversion.AllowPointerConditions
     value: 'false'
   - key: readability-implicit-bool-conversion.AllowIntegerConditions
     value: 'false'
 
-  # Misc safety settings
+  # Comprehensive error checking for C standard library functions
   - key: cert-err33-c.CheckedFunctions
     value: '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fgetws;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcrtomb_s;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,155 @@
+---
+# Strict clang-tidy configuration for production C code
+# Focuses on MISRA C compliance and embedded systems best practices
+
+Checks: >
+  bugprone-*,
+  cert-dcl03-c,
+  cert-dcl37-c,
+  cert-dcl51-c,
+  cert-env33-c,
+  cert-err33-c,
+  cert-err34-c,
+  cert-fio30-c,
+  cert-fio38-c,
+  cert-flp30-c,
+  cert-int31-c,
+  cert-msc30-c,
+  cert-msc32-c,
+  cert-pos44-c,
+  cert-str31-c,
+  cert-str32-c,
+  cert-str34-c,
+  clang-analyzer-*,
+  clang-analyzer-core.NullDereference,
+  clang-analyzer-core.uninitialized.*,
+  clang-analyzer-core.DivideZero,
+  clang-analyzer-core.NonNullParamChecker,
+  cppcoreguidelines-avoid-goto,
+  cppcoreguidelines-init-variables,
+  cppcoreguidelines-no-malloc,
+  misc-definitions-in-headers,
+  misc-misplaced-const,
+  misc-redundant-expression,
+  misc-static-assert,
+  misc-throw-by-value-catch-by-reference,
+  misc-unconventional-assign-operator,
+  misc-uniqueptr-reset-release,
+  misc-unused-alias-decls,
+  misc-unused-parameters,
+  misc-unused-using-decls,
+  performance-faster-string-find,
+  performance-for-range-copy,
+  performance-implicit-conversion-in-loop,
+  performance-inefficient-algorithm,
+  performance-inefficient-string-concatenation,
+  performance-inefficient-vector-operation,
+  performance-move-const-arg,
+  performance-move-constructor-init,
+  performance-noexcept-move-constructor,
+  performance-trivially-destructible,
+  performance-type-promotion-in-math-fn,
+  performance-unnecessary-copy-initialization,
+  performance-unnecessary-value-param,
+  portability-restrict-system-includes,
+  portability-simd-intrinsics,
+  readability-avoid-const-params-in-decls,
+  readability-braces-around-statements,
+  readability-const-return-type,
+  readability-delete-null-pointer,
+  readability-deleted-default,
+  readability-else-after-return,
+  readability-function-size,
+  readability-identifier-naming,
+  readability-implicit-bool-conversion,
+  readability-inconsistent-declaration-parameter-name,
+  readability-isolate-declaration,
+  readability-magic-numbers,
+  readability-make-member-function-const,
+  readability-misleading-indentation,
+  readability-misplaced-array-index,
+  readability-named-parameter,
+  readability-non-const-parameter,
+  readability-redundant-control-flow,
+  readability-redundant-declaration,
+  readability-redundant-function-ptr-dereference,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr,
+  readability-redundant-string-init,
+  readability-simplify-boolean-expr,
+  readability-simplify-subscript-expr,
+  readability-static-accessed-through-instance,
+  readability-static-definition-in-anonymous-namespace,
+  readability-string-compare,
+  readability-uppercase-literal-suffix,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-macro-parentheses,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  -misc-unused-parameters
+
+# Exclude vendor SDK and external dependencies
+# HeaderFilterRegex: '^(?!.*(gtest|gmock|third_party|build/_deps|\.conan|/sdk/)).*platforms/.*/hal/.*\.(h|c)$'
+HeaderFilterRegex: '.*(hal_interface|platforms/stm32f446re/hal)/.*\.(h|hpp)$'
+
+CheckOptions:
+  # MISRA-style naming conventions
+  - key: readability-identifier-naming.FunctionCase
+    value: lower_case
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.LocalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.StaticVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MacroCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.StructCase
+    value: lower_case
+  - key: readability-identifier-naming.TypedefCase
+    value: lower_case
+  - key: readability-identifier-naming.UnionCase
+    value: lower_case
+
+  # Function and complexity limits (MISRA-inspired)
+  - key: readability-function-size.LineThreshold
+    value: '50'
+  - key: readability-function-size.StatementThreshold
+    value: '40'
+  - key: readability-function-size.BranchThreshold
+    value: '10'
+  - key: readability-function-size.ParameterThreshold
+    value: '5'
+  - key: readability-function-size.NestingThreshold
+    value: '4'
+  - key: readability-function-size.VariableThreshold
+    value: '10'
+
+  # Magic numbers (strict for embedded)
+  - key: readability-magic-numbers.IgnoredIntegerValues
+    value: '0;1;2;-1'
+  - key: readability-magic-numbers.IgnoredFloatingPointValues
+    value: '0.0;1.0;-1.0'
+
+  # Bracing style
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: '0'
+
+  # Implicit conversions
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: 'false'
+  - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: 'false'
+
+  # Misc safety settings
+  - key: cert-err33-c.CheckedFunctions
+    value: '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fgetws;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcrtomb_s;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -85,7 +85,8 @@ WarningsAsErrors: >
   bugprone-sizeof-expression,
   bugprone-suspicious-memory-comparison,
   bugprone-infinite-loop,
-  bugprone-macro-parentheses
+  bugprone-macro-parentheses,
+  readability-magic-numbers
 
 # Target embedded C code, exclude vendor SDK and external dependencies
 HeaderFilterRegex: '.*(hal_interface|platforms/stm32f446re/hal)/.*\.(h|c)$'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-# Production-grade clang-tidy configuration for embedded C projects
+# clang-tidy configuration for embedded C projects
 # Focuses on MISRA C compliance, safety-critical requirements, and embedded systems best practices
 
 Checks: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,23 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(STM32F4_HAL_SOURCES
-    platforms/stm32f446re/hal/stm32f4_gpio.c
-    platforms/stm32f446re/hal/stm32f4_systick.c
-    platforms/stm32f446re/hal/uart/src/stm32f4_uart.c
-    platforms/stm32f446re/hal/uart/src/stm32f4_uart1.c
-    platforms/stm32f446re/hal/uart/src/stm32f4_uart2.c
-)
-
 # Build options
 option(SIMULATION_BUILD "Build for desktop simulation" OFF)
 option(EMBEDDED_BUILD "Build for embedded target" OFF)
+option(STATIC_ANALYSIS_BUILD "Build to run static analysis" OFF)
 
 # Ensure only one target build type is selected
 if(SIMULATION_BUILD AND EMBEDDED_BUILD)
   message(FATAL_ERROR "Cannot enable both SIMULATION_BUILD and EMBEDDED_BUILD at the same time.")
 endif()
+if(STATIC_ANALYSIS_BUILD AND EMBEDDED_BUILD)
+  message(FATAL_ERROR "Cannot enable both STATIC_ANALYSIS_BUILD and EMBEDDED_BUILD at the same time.")
+endif()
+if(STATIC_ANALYSIS_BUILD AND SIMULATION_BUILD)
+  message(FATAL_ERROR "Cannot enable both STATIC_ANALYSIS_BUILD and SIMULATION_BUILD at the same time.")
+endif()
 
-# Default to embedded build if nothing specified
-if(NOT SIMULATION_BUILD AND NOT EMBEDDED_BUILD)
+# Default to static analysis build if nothing specified
+if(NOT SIMULATION_BUILD AND NOT EMBEDDED_BUILD AND NOT STATIC_ANALYSIS_BUILD)
   message(STATUS "No build type specified -- defaulting to STATIC_ANALYSIS_BUILD")
   set(STATIC_ANALYSIS_BUILD ON)
 endif()
@@ -67,32 +66,11 @@ if(EMBEDDED_BUILD)
 endif()
 
 if(STATIC_ANALYSIS_BUILD)
+  message(STATUS "Building static analysis...")
+
+  add_subdirectory(hal_interface)
   add_subdirectory(simulations/stm32f446re/stm32f4_mocks)
   add_subdirectory(external/circular_buffer)
-
-  add_library(
-    ${PROJECT_NAME}_static_analysis_target
-    ${STM32F4_HAL_SOURCES}
-  )
-
-  target_link_libraries(
-    ${PROJECT_NAME}_static_analysis_target
-    stm32f4_mock
-    circular_buffer
-  )
-
-  target_include_directories(
-    ${PROJECT_NAME}_static_analysis_target
-    PUBLIC
-    hal_interface/include
-    platforms/stm32f446re/hal/include
-    platforms/stm32f446re/hal/uart/include
-  )
-
-  target_compile_definitions(
-    ${PROJECT_NAME}_static_analysis_target
-    PRIVATE
-    SIMULATION_BUILD
-  )
+  add_subdirectory(platforms/stm32f446re/hal)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.20)
 
+set(STM32F4_HAL_SOURCES
+    platforms/stm32f446re/hal/stm32f4_gpio.c
+    platforms/stm32f446re/hal/stm32f4_systick.c
+    platforms/stm32f446re/hal/uart/src/stm32f4_uart.c
+    platforms/stm32f446re/hal/uart/src/stm32f4_uart1.c
+    platforms/stm32f446re/hal/uart/src/stm32f4_uart2.c
+)
+
 # Build options
 option(SIMULATION_BUILD "Build for desktop simulation" OFF)
 option(EMBEDDED_BUILD "Build for embedded target" OFF)
@@ -11,8 +19,8 @@ endif()
 
 # Default to embedded build if nothing specified
 if(NOT SIMULATION_BUILD AND NOT EMBEDDED_BUILD)
-  message(STATUS "No build type specified -- defaulting to EMBEDDED_BUILD")
-  set(EMBEDDED_BUILD ON)
+  message(STATUS "No build type specified -- defaulting to STATIC_ANALYSIS_BUILD")
+  set(STATIC_ANALYSIS_BUILD ON)
 endif()
 
 set(PROJECT_NAME "hal")
@@ -34,6 +42,7 @@ if(SIMULATION_BUILD)
   FetchContent_MakeAvailable(googletest)
 
   add_subdirectory(simulations)
+  add_subdirectory(external/circular_buffer)
   include(CTest)
 endif()
 
@@ -42,6 +51,7 @@ if(EMBEDDED_BUILD)
 
   add_subdirectory(platforms)
   add_subdirectory(hal_interface)
+  add_subdirectory(external/circular_buffer)
 
   add_executable(
       ${PROJECT_NAME}.elf
@@ -56,4 +66,33 @@ if(EMBEDDED_BUILD)
   )
 endif()
 
-add_subdirectory(external/circular_buffer)
+if(STATIC_ANALYSIS_BUILD)
+  add_subdirectory(simulations/stm32f446re/stm32f4_mocks)
+  add_subdirectory(external/circular_buffer)
+
+  add_library(
+    ${PROJECT_NAME}_static_analysis_target
+    ${STM32F4_HAL_SOURCES}
+  )
+
+  target_link_libraries(
+    ${PROJECT_NAME}_static_analysis_target
+    stm32f4_mock
+    circular_buffer
+  )
+
+  target_include_directories(
+    ${PROJECT_NAME}_static_analysis_target
+    PUBLIC
+    hal_interface/include
+    platforms/stm32f446re/hal/include
+    platforms/stm32f446re/hal/uart/include
+  )
+
+  target_compile_definitions(
+    ${PROJECT_NAME}_static_analysis_target
+    PRIVATE
+    SIMULATION_BUILD
+  )
+endif()
+

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,27 @@
                 "SIMULATION_BUILD": "ON",
                 "EMBEDDED_BUILD": "OFF",
                 "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_CXX_STANDARD": "14"
+            }
+        },
+        {
+            "name": "static-analysis",
+            "displayName": "Static Analysis",
+            "description": "Static analysis of production C code using clang-tidy",
+            "binaryDir": "${sourceDir}/build/static-analysis",
+            "cacheVariables": {
+                "STATIC_ANALYSIS_BUILD": "ON",
+                "EMBEDDED_BUILD": "OFF",
+                "SIMULATION_BUILD": "OFF",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_FLAGS": "",
+                "CMAKE_EXE_LINKER_FLAGS": "",
+                "CMAKE_TRY_COMPILE_TARGET_TYPE": "STATIC_LIBRARY",
+                "CMAKE_C_CLANG_TIDY": "clang-tidy;--config-file=${sourceDir}/.clang-tidy;--header-filter=^(?!.*(gtest|gmock|third_party|build/_deps|\\.conan|/sdk/)).*platforms/.*/hal/.*\\.(h|c)$"
             }
         },
         {
@@ -22,7 +42,8 @@
             "cacheVariables": {
                 "EMBEDDED_BUILD": "ON",
                 "SIMULATION_BUILD": "OFF",
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             }
         },
         {
@@ -34,7 +55,8 @@
             "cacheVariables": {
                 "EMBEDDED_BUILD": "ON",
                 "SIMULATION_BUILD": "OFF",
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             }
         }
     ],
@@ -43,6 +65,11 @@
             "name": "desktop-debug",
             "displayName": "Build Desktop (Debug)",
             "configurePreset": "desktop-debug"
+        },
+        {
+            "name": "static-analysis",
+            "displayName": "Run Static Analysis",
+            "configurePreset": "static-analysis"
         },
         {
             "name": "embedded-debug",

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
     valgrind \
     libgtest-dev \
     gcc-arm-none-eabi \
-    gdb-arm-none-eabi
+    gdb-arm-none-eabi \
+    clang
 
 # Set working directory
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
     libgtest-dev \
     gcc-arm-none-eabi \
     gdb-arm-none-eabi \
-    clang
+    clang \
+    clang-tidy
 
 # Set working directory
 WORKDIR /workspace

--- a/platforms/stm32f446re/hal/CMakeLists.txt
+++ b/platforms/stm32f446re/hal/CMakeLists.txt
@@ -6,5 +6,13 @@ add_library(
     uart/src/stm32f4_uart1.c
     uart/src/stm32f4_uart2.c
 )
-target_link_libraries(stm32f4_hal PUBLIC hal_interface PRIVATE stm32f446re_sdk circular_buffer)
+
+# Link against the mocks for static analysis to avoid analyzing vendor sdk.
+if (STATIC_ANALYSIS_BUILD)
+    target_link_libraries(stm32f4_hal PUBLIC hal_interface PRIVATE stm32f4_mock circular_buffer)
+    target_compile_definitions(stm32f4_hal PRIVATE SIMULATION_BUILD)
+else()
+    target_link_libraries(stm32f4_hal PUBLIC hal_interface PRIVATE stm32f446re_sdk circular_buffer)
+endif()
+
 target_include_directories(stm32f4_hal PRIVATE ./uart/include ./include)

--- a/platforms/stm32f446re/hal/stm32f4_gpio.c
+++ b/platforms/stm32f446re/hal/stm32f4_gpio.c
@@ -1,4 +1,8 @@
+#ifdef SIMULATION_BUILD
+#include "registers.h"
+#else
 #include "stm32f4xx.h"
+#endif
 #include "gpio.h"
 
 #define GPIOAEN (1U << 0)

--- a/platforms/stm32f446re/hal/stm32f4_systick.c
+++ b/platforms/stm32f446re/hal/stm32f4_systick.c
@@ -1,4 +1,8 @@
+#ifdef SIMULATION_BUILD
+#include "registers.h"
+#else
 #include "stm32f4xx.h"
+#endif
 #include "systick.h"
 
 #define SYSTICK_LOAD_VAL 16000

--- a/platforms/stm32f446re/hal/uart/src/stm32f4_uart1.c
+++ b/platforms/stm32f446re/hal/uart/src/stm32f4_uart1.c
@@ -1,4 +1,9 @@
+#ifdef SIMULATION_BUILD
+#include "registers.h"
+#include "nvic.h"
+#else
 #include "stm32f4xx.h"
+#endif
 #include "stm32f4_uart1.h"
 
 // @todo implement

--- a/simulations/stm32f446re/CMakeLists.txt
+++ b/simulations/stm32f446re/CMakeLists.txt
@@ -1,14 +1,4 @@
-# Mock stm32f4 hardware.
-add_library(
-    stm32f4_mock
-    stm32f4_mocks/src/registers.c
-)
-
-target_include_directories(
-    stm32f4_mock
-    PUBLIC
-    stm32f4_mocks/include
-)
+add_subdirectory(stm32f4_mocks)
 
 # The real hardware driver compiled for desktop.
 add_library(

--- a/simulations/stm32f446re/stm32f4_mocks/CMakeLists.txt
+++ b/simulations/stm32f446re/stm32f4_mocks/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Mock stm32f4 hardware.
+add_library(
+    stm32f4_mock
+    src/registers.c
+)
+
+target_include_directories(
+    stm32f4_mock
+    PUBLIC
+    include
+)

--- a/simulations/stm32f446re/stm32f4_mocks/include/nvic.h
+++ b/simulations/stm32f446re/stm32f4_mocks/include/nvic.h
@@ -3,6 +3,7 @@ extern "C" {
 #endif
 
 #define USART2_IRQn 38
+#define USART1_IRQn 37
 
 // Very minimal NVIC simulation
 #define NVIC_EnableIRQ(x) ((void)(x))  // No-op

--- a/simulations/stm32f446re/stm32f4_mocks/include/registers.h
+++ b/simulations/stm32f446re/stm32f4_mocks/include/registers.h
@@ -49,6 +49,17 @@ typedef struct {
 extern USART_TypeDef Sim_USART2;
 #define USART2 (&Sim_USART2)
 
+typedef struct
+{
+  volatile uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  volatile uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  volatile uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  volatile uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+extern SysTick_Type Sim_SysTick;
+#define SysTick (&Sim_SysTick)
+
 // USART flags (copy from stm32f4xx.h)
 #define USART_SR_RXNE (1U << 5)
 #define USART_SR_TXE  (1U << 7)

--- a/simulations/stm32f446re/stm32f4_mocks/src/registers.c
+++ b/simulations/stm32f446re/stm32f4_mocks/src/registers.c
@@ -4,3 +4,4 @@
 RCC_TypeDef Sim_RCC = {0};
 GPIO_TypeDef Sim_GPIOA = {0};
 USART_TypeDef Sim_USART2 = {0};
+SysTick_Type Sim_SysTick = {0};


### PR DESCRIPTION
# Static Analysis for the Code Base
This PR adds an additional CMake Configuration Preset for statically analyzing the C files intended for production.

## Context
Static analysis can improve the quality of code by catching errors and common mistakes earlier. 

## Changes
- Adds `Static Analysis` configuration preset
- Adds `clang` and `clang-tidy` tools to the environment
- Adds `.clang-tidy` configuration file defining the programming rules to check against
- Builds fail for violating certain rules (null dereference, divide by zero, magic numbers, etc)

## Recommended Usage
For now, run manually throughout the development process to ensure compliance with best practices and especially before submitting a PR for review. In the future, this will be a required gate to pass before merging a PR via CI/CD Pipeline.

## Notes
The target files under analysis are linked against the stm32f4 mock library and analyzed on desktop using clang's desktop compiler. This is to prevent the vendor sdk and other third party code from being analyzed. It also simplifies using clang-tidy, since clang does not natively understand the cross compilation arguments provided to arm-none-eabi-gcc.

## Room for Future Improvement
Using the static analysis build currently presents a usability hurdle. Right now, the best way to use this tool is to switch to the `Static Analysis` preset, delete `build/static-analysis` if it exists, reload the vscode window, then press build. Following these steps results in a build log output containing all warnings, errors, and findings and also allows vscode to highlight the problem areas. However, if not building from a clean slate, previously reported errors will not be shown again, and it may appear that everything is fine. This is an area of active research and improvement.