### PR TITLE
NE-38: Add cppcheck to Target and Desktop Builds

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -86,6 +86,7 @@ WarningsAsErrors: >
   bugprone-suspicious-memory-comparison,
   bugprone-infinite-loop,
   bugprone-macro-parentheses,
+  clang-diagnostic-array-bounds,
   # readability-magic-numbers TODO: Uncomment this to enforce.
 
 # Target embedded C code, exclude vendor SDK and external dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(PROJECT_NAME "hal")
 
 project(${PROJECT_NAME} LANGUAGES C ASM CXX)
 
+find_program(CPPCHECK_EXECUTABLE NAMES cppcheck REQUIRED)
+
 if(SIMULATION_BUILD)
   message(STATUS "Building desktop simulation...")
 
@@ -43,6 +45,15 @@ if(SIMULATION_BUILD)
   add_subdirectory(simulations)
   add_subdirectory(external/circular_buffer)
   include(CTest)
+
+  add_custom_target(cppcheck ALL
+      COMMAND ${CPPCHECK_EXECUTABLE}
+          --error-exitcode=1
+          --project=build/desktop-debug/compile_commands.json
+          -i_deps
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      COMMENT "Running cppcheck analysis..."
+  )
 endif()
 
 if(EMBEDDED_BUILD)
@@ -62,6 +73,14 @@ if(EMBEDDED_BUILD)
   add_custom_target(${PROJECT_NAME}.bin ALL
       arm-none-eabi-objcopy -O binary ${PROJECT_NAME}.elf ${PROJECT_NAME}.bin
       DEPENDS ${PROJECT_NAME}.elf
+  )
+
+  add_custom_target(cppcheck ALL
+      COMMAND ${CPPCHECK_EXECUTABLE}
+          --error-exitcode=1
+          --project=build/embedded-debug/compile_commands.json
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      COMMENT "Running cppcheck analysis..."
   )
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y \
     gcc-arm-none-eabi \
     gdb-arm-none-eabi \
     clang \
-    clang-tidy
+    clang-tidy \
+    cppcheck
 
 # Set working directory
 WORKDIR /workspace


### PR DESCRIPTION
# Context
To ensure the code is being statically analyzed thoroughly a second static analyzer is necessary. This approach makes it more likely that blind spots in one analyzer will be caught by the other. There was also a need for an analyzer that integrated more tightly with the development environment.

# Changes
- Add `cppcheck` to the container.
- Run `cppcheck` on every build for `target` and `desktop`.
- Builds fail when `cppcheck` identify an error.
- `clang-tidy` now fails `static-analysis` builds for out-of-bounds array access