### PR TITLE
NE-40: Add Target Debugger

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
                 "ms-vscode.cmake-tools",
                 "ms-vscode.cpptools",
                 "ms-vscode.cpptools-extension-pack",
-                "twxs.cmake"
+                "twxs.cmake",
+                "marus25.cortex-debug"
             ],
             "settings": {
                 "cmake.useCMakePresets": "always",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,5 +23,18 @@
             // Add LD_LIBRARY_PATH etc. here if your test exe needs it
             ]
         },
+        {
+            "name": "Target Debug: hal.elf",
+            "type": "cortex-debug",
+            "request": "launch",
+            "servertype": "stlink", // or "jlink", "openocd", "pyocd", etc.
+            "cwd": "${workspaceFolder}",
+            "executable": "${workspaceFolder}/build/embedded-debug/hal.elf",
+            "device": "STM32F446RE", // exact device name
+            // "svdFile": "${workspaceFolder}/svd/STM32F446xx.svd", // optional but helpful
+            "configFiles": [], // if using OpenOCD, e.g. ["interface/stlink.cfg", "target/stm32f4x.cfg"]
+            "postRestartCommands": ["monitor reset halt"],
+            "showDevDebugOutput": "parsed"
+        }
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cmake.useCMakePresets": "always",
     "cmake.configureOnOpen": false,
-    "cmake.options.statusBarVisibility": "visible"
+    "cmake.options.statusBarVisibility": "visible",
+    "cortex-debug.gdbPath": "/Users/cory/.bin/arm_toolchain/arm-gnu-toolchain-14.2.rel1-darwin-arm64-arm-none-eabi/bin/arm-none-eabi-gdb"
 }


### PR DESCRIPTION
# Context
The ability to live debug on target helps a lot when troubleshooting complex issues.

# Changes
WIP