### PR TITLE
NE-44: Add Bytes Written Param

### DIFF
--- a/hal_interface/include/uart.h
+++ b/hal_interface/include/uart.h
@@ -20,7 +20,7 @@ int __io_putchar(int ch);
 HalStatus_t hal_uart_init(HalUart_t uart, void *config);
 HalStatus_t hal_uart_deinit(HalUart_t uart);
 HalStatus_t hal_uart_read(HalUart_t uart, uint8_t *data, size_t len, size_t *bytes_read, uint32_t timeout_ms);
-HalStatus_t hal_uart_write(HalUart_t uart, const uint8_t *data, size_t len);
+HalStatus_t hal_uart_write(HalUart_t uart, const uint8_t *data, size_t len, size_t *bytes_written);
 HalStatus_t hal_uart_get_stats(HalUart_t uart, HalUartStats_t *stats);
 
 #endif /* _UART_H */

--- a/platforms/stm32f446re/hal/uart/include/stm32f4_uart1.h
+++ b/platforms/stm32f446re/hal/uart/include/stm32f4_uart1.h
@@ -6,6 +6,6 @@
 HalStatus_t stm32f4_uart1_init(void *config);
 HalStatus_t stm32f4_uart1_deinit();
 HalStatus_t stm32f4_uart1_read(uint8_t *data, size_t len, size_t *bytes_read, uint32_t timeout_ms);
-HalStatus_t stm32f4_uart1_write(const uint8_t *data, size_t len);
+HalStatus_t stm32f4_uart1_write(const uint8_t *data, size_t len, size_t *bytes_written);
 
 #endif /* _STM32F4_UART1_H */

--- a/platforms/stm32f446re/hal/uart/include/stm32f4_uart2.h
+++ b/platforms/stm32f446re/hal/uart/include/stm32f4_uart2.h
@@ -6,6 +6,6 @@
 HalStatus_t stm32f4_uart2_init(void *config);
 HalStatus_t stm32f4_uart2_deinit();
 HalStatus_t stm32f4_uart2_read(uint8_t *data, size_t len, size_t *bytes_read, uint32_t timeout_ms);
-HalStatus_t stm32f4_uart2_write(const uint8_t *data, size_t len);
+HalStatus_t stm32f4_uart2_write(const uint8_t *data, size_t len, size_t *bytes_written);
 
 #endif /* _STM32F4_UART2_H */

--- a/platforms/stm32f446re/hal/uart/src/stm32f4_uart.c
+++ b/platforms/stm32f446re/hal/uart/src/stm32f4_uart.c
@@ -7,11 +7,11 @@
  */
 int __io_putchar(int ch)
 {
-	uint8_t data[] = { 0 };
-	data[0] = ch;
-	size_t len = 1;
+	uint8_t data[1] = { 0 };
+	size_t bytes_written = 0;
 
-	hal_uart_write(HAL_UART2, &data[0], len);
+	data[0] = ch;
+	hal_uart_write(HAL_UART2, data, sizeof(data), &bytes_written);
 
 	return ch;
 }
@@ -76,17 +76,17 @@ HalStatus_t hal_uart_read(HalUart_t uart, uint8_t *data, size_t len, size_t *byt
 	return hal_status;
 }
 
-HalStatus_t hal_uart_write(HalUart_t uart, const uint8_t *data, size_t len)
+HalStatus_t hal_uart_write(HalUart_t uart, const uint8_t *data, size_t len, size_t *bytes_written)
 {
 	HalStatus_t hal_status = HAL_STATUS_ERROR;
 
 	if (uart == HAL_UART1)
 	{
-		hal_status = stm32f4_uart1_write(data, len);
+		hal_status = stm32f4_uart1_write(data, len, bytes_written);
 	}
 	else if (uart == HAL_UART2)
 	{
-		hal_status = stm32f4_uart2_write(data, len);
+		hal_status = stm32f4_uart2_write(data, len, bytes_written);
 	}
 	else if (uart == HAL_UART3)
 	{

--- a/platforms/stm32f446re/hal/uart/src/stm32f4_uart1.c
+++ b/platforms/stm32f446re/hal/uart/src/stm32f4_uart1.c
@@ -131,14 +131,14 @@ HalStatus_t stm32f4_uart1_read(uint8_t *data, size_t len, size_t *bytes_read, ui
     return res;
 }
 
-HalStatus_t stm32f4_uart1_write(const uint8_t *data, size_t len)
+HalStatus_t stm32f4_uart1_write(const uint8_t *data, size_t len, size_t *bytes_written)
 {
 	HalStatus_t res = HAL_STATUS_ERROR;
-	size_t bytes_written = 0;
 	bool push_success = true;
 
-	if (uart1_initialized && data && len > 0)
+	if (uart1_initialized && bytes_written && data && len > 0)
 	{
+		*bytes_written = 0;
 		for (size_t i = 0; i < len; i++)
 		{
 			// ***************************************************
@@ -151,7 +151,7 @@ HalStatus_t stm32f4_uart1_write(const uint8_t *data, size_t len)
 
 			if (push_success)
 			{
-				bytes_written++;
+				*bytes_written += 1;
 			}
 			else
 			{
@@ -161,14 +161,14 @@ HalStatus_t stm32f4_uart1_write(const uint8_t *data, size_t len)
 
 		// If bytes were written successfully to buffer, then enable the transmit
 		// interrupt because those bytes need to be sent out.
-		if (bytes_written > 0)
+		if (*bytes_written > 0)
 		{
 			USART1->CR1 |= USART_CR1_TXEIE;  // Enable TXE interrupt
 		}
 
 		// If we successfully wrote all bytes to buffer, then the function was an
 		// overall success.
-		res = (bytes_written == len) ? HAL_STATUS_OK : HAL_STATUS_ERROR;
+		res = (*bytes_written == len) ? HAL_STATUS_OK : HAL_STATUS_ERROR;
 	}
 
 	return res;

--- a/platforms/stm32f446re/hal/uart/src/stm32f4_uart2.c
+++ b/platforms/stm32f446re/hal/uart/src/stm32f4_uart2.c
@@ -140,14 +140,14 @@ HalStatus_t stm32f4_uart2_read(uint8_t *data, size_t len, size_t *bytes_read, ui
 /**
  * @brief Writes data to UART2 register.
 */
-HalStatus_t stm32f4_uart2_write(const uint8_t *data, size_t len)
+HalStatus_t stm32f4_uart2_write(const uint8_t *data, size_t len, size_t *bytes_written)
 {
 	HalStatus_t res = HAL_STATUS_ERROR;
-	size_t bytes_written = 0;
 	bool push_success = true;
 
-	if (uart2_initialized && data && len > 0)
+	if (uart2_initialized && bytes_written && data && len > 0)
 	{
+		*bytes_written = 0;
 		for (size_t i = 0; i < len; i++)
 		{
 			// ***************************************************
@@ -160,7 +160,7 @@ HalStatus_t stm32f4_uart2_write(const uint8_t *data, size_t len)
 
 			if (push_success)
 			{
-				bytes_written++;
+				*bytes_written += 1;
 			}
 			else
 			{
@@ -170,14 +170,14 @@ HalStatus_t stm32f4_uart2_write(const uint8_t *data, size_t len)
 
 		// If bytes were written successfully to buffer, then enable the transmit
 		// interrupt because those bytes need to be sent out.
-		if (bytes_written > 0)
+		if (*bytes_written > 0)
 		{
 			USART2->CR1 |= USART_CR1_TXEIE;  // Enable TXE interrupt
 		}
 
 		// If we successfully wrote all bytes to buffer, then the function was an
 		// overall success.
-		res = (bytes_written == len) ? HAL_STATUS_OK : HAL_STATUS_ERROR;
+		res = (*bytes_written == len) ? HAL_STATUS_OK : HAL_STATUS_ERROR;
 	}
 
 	return res;

--- a/simulations/stm32f446re/test/uart_driver_test.cpp
+++ b/simulations/stm32f446re/test/uart_driver_test.cpp
@@ -498,45 +498,49 @@ TEST_F(UartDriverTest, Uart2BufferStateConsistency)
 TEST_F(UartDriverTest, WriteFailsForNullData)
 {
     size_t data_len = 10;
+    size_t bytes_written = 0;
 
     // UART1 test
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART1, nullptr, data_len), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, nullptr, data_len, &bytes_written), HAL_STATUS_ERROR);
 
     // UART2 test
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, nullptr, data_len), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, nullptr, data_len, &bytes_written), HAL_STATUS_ERROR);
 }
 
 TEST_F(UartDriverTest, WriteFailsForZeroLength)
 {
     uint8_t data[] = "Hello";
+    size_t bytes_written = 0;
 
     // UART1 test
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data, 0), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data, 0, &bytes_written), HAL_STATUS_ERROR);
 
     // UART2 test
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data, 0), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data, 0, &bytes_written), HAL_STATUS_ERROR);
 }
 
 TEST_F(UartDriverTest, WriteFailsForInvalidUart)
 {
     uint8_t data[] = "Test";
     size_t data_len = sizeof(data) - 1;
+    size_t bytes_written = 0;
 
-    ASSERT_EQ(hal_uart_write((HalUart_t)(-1), data, data_len), HAL_STATUS_ERROR);
-    ASSERT_EQ(hal_uart_write(HAL_UART3, data, data_len), HAL_STATUS_ERROR); // Not implemented
-    ASSERT_EQ(hal_uart_write((HalUart_t)(99), data, data_len), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write((HalUart_t)(-1), data, data_len, &bytes_written), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART3, data, data_len, &bytes_written), HAL_STATUS_ERROR); // Not implemented
+    ASSERT_EQ(hal_uart_write((HalUart_t)(99), data, data_len, &bytes_written), HAL_STATUS_ERROR);
 }
 
 TEST_F(UartDriverTest, Uart1WritesSingleByte)
 {
     uint8_t data[] = {'A'};
+    size_t bytes_written = 0;
 
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data, 1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data, 1, &bytes_written), HAL_STATUS_OK);
 
     // Verify TXE interrupt was enabled (buffer was empty before write)
     ASSERT_TRUE(Sim_USART1.CR1 & USART_CR1_TXEIE);
@@ -559,9 +563,10 @@ TEST_F(UartDriverTest, Uart1WritesSingleByte)
 TEST_F(UartDriverTest, Uart2WritesSingleByte)
 {
     uint8_t data[] = {'A'};
+    size_t bytes_written = 0;
 
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data, 1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data, 1, &bytes_written), HAL_STATUS_OK);
 
     // Verify TXE interrupt was enabled
     ASSERT_TRUE(Sim_USART2.CR1 & USART_CR1_TXEIE);
@@ -583,6 +588,7 @@ TEST_F(UartDriverTest, Uart1WritesMultipleBytes)
 {
     const size_t DATA_LEN = 10;
     uint8_t data[DATA_LEN];
+    size_t bytes_written = 0;
 
     // Create test pattern
     for (int i = 0; i < DATA_LEN; i++) {
@@ -590,7 +596,7 @@ TEST_F(UartDriverTest, Uart1WritesMultipleBytes)
     }
 
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data, DATA_LEN), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data, DATA_LEN, &bytes_written), HAL_STATUS_OK);
 
     // Verify TXE interrupt was enabled
     ASSERT_TRUE(Sim_USART1.CR1 & USART_CR1_TXEIE);
@@ -614,13 +620,14 @@ TEST_F(UartDriverTest, Uart2WritesMultipleBytes)
 {
     const size_t DATA_LEN = 10;
     uint8_t data[DATA_LEN];
+    size_t bytes_written = 0;
 
     for (int i = 0; i < DATA_LEN; i++) {
         data[i] = 'A' + i;
     }
 
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data, DATA_LEN), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data, DATA_LEN, &bytes_written), HAL_STATUS_OK);
 
     ASSERT_TRUE(Sim_USART2.CR1 & USART_CR1_TXEIE);
 
@@ -641,13 +648,14 @@ TEST_F(UartDriverTest, Uart1WritesMaxBufferSize)
 {
     const size_t DATA_LEN = CIRCULAR_BUFFER_MAX_SIZE;
     uint8_t data[DATA_LEN];
+    size_t bytes_written = 0;
 
     for (int i = 0; i < DATA_LEN; i++) {
         data[i] = (uint8_t)(i & 0xFF);
     }
 
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data, DATA_LEN), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data, DATA_LEN, &bytes_written), HAL_STATUS_OK);
 
     // Simulate transmission of all bytes
     for (int i = 0; i < DATA_LEN; i++) {
@@ -661,13 +669,14 @@ TEST_F(UartDriverTest, Uart2WritesMaxBufferSize)
 {
     const size_t DATA_LEN = CIRCULAR_BUFFER_MAX_SIZE;
     uint8_t data[DATA_LEN];
+    size_t bytes_written = 0;
 
     for (int i = 0; i < DATA_LEN; i++) {
         data[i] = (uint8_t)(i & 0xFF);
     }
 
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data, DATA_LEN), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data, DATA_LEN, &bytes_written), HAL_STATUS_OK);
 
     for (int i = 0; i < DATA_LEN; i++) {
         Sim_USART2.SR |= USART_SR_TXE;
@@ -680,6 +689,7 @@ TEST_F(UartDriverTest, Uart1WriteFailsWhenBufferFull)
 {
     const size_t DATA_LEN = CIRCULAR_BUFFER_MAX_SIZE + 1; // One byte too many
     uint8_t data[DATA_LEN];
+    size_t bytes_written = 0;
 
     for (int i = 0; i < DATA_LEN; i++) {
         data[i] = 'X';
@@ -688,7 +698,7 @@ TEST_F(UartDriverTest, Uart1WriteFailsWhenBufferFull)
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
     // This should fail because we're trying to write more than buffer capacity
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data, DATA_LEN), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data, DATA_LEN, &bytes_written), HAL_STATUS_ERROR);
 
     // @todo reevaluate this requirement.
     // TXE interrupt should NOT be enabled since write failed
@@ -699,13 +709,14 @@ TEST_F(UartDriverTest, Uart2WriteFailsWhenBufferFull)
 {
     const size_t DATA_LEN = CIRCULAR_BUFFER_MAX_SIZE + 1;
     uint8_t data[DATA_LEN];
+    size_t bytes_written = 0;
 
     for (int i = 0; i < DATA_LEN; i++) {
         data[i] = 'X';
     }
 
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data, DATA_LEN), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data, DATA_LEN, &bytes_written), HAL_STATUS_ERROR);
 
     // @todo reevaluate this requirement.
     // ASSERT_FALSE(Sim_USART2.CR1 & USART_CR1_TXEIE);
@@ -717,6 +728,7 @@ TEST_F(UartDriverTest, Uart1WritePartialThenComplete)
     const size_t SECOND_WRITE = CIRCULAR_BUFFER_MAX_SIZE / 4;
     uint8_t data1[FIRST_WRITE];
     uint8_t data2[SECOND_WRITE];
+    size_t bytes_written = 0;
 
     // Prepare test data
     for (int i = 0; i < FIRST_WRITE; i++) {
@@ -729,7 +741,7 @@ TEST_F(UartDriverTest, Uart1WritePartialThenComplete)
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
     // First write
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data1, FIRST_WRITE), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data1, FIRST_WRITE, &bytes_written), HAL_STATUS_OK);
 
     // Partially transmit first write (transmit half)
     for (int i = 0; i < FIRST_WRITE / 2; i++) {
@@ -739,7 +751,7 @@ TEST_F(UartDriverTest, Uart1WritePartialThenComplete)
     }
 
     // Second write should succeed (there's still space)
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data2, SECOND_WRITE), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data2, SECOND_WRITE, &bytes_written), HAL_STATUS_OK);
 
     // Complete transmission - should get remaining A's then B's
     for (int i = 0; i < (FIRST_WRITE / 2); i++) {
@@ -768,6 +780,7 @@ TEST_F(UartDriverTest, Uart2WritePartialThenComplete)
     const size_t SECOND_WRITE = CIRCULAR_BUFFER_MAX_SIZE / 4;
     uint8_t data1[FIRST_WRITE];
     uint8_t data2[SECOND_WRITE];
+    size_t bytes_written = 0;
 
     for (int i = 0; i < FIRST_WRITE; i++) {
         data1[i] = 'A';
@@ -778,7 +791,7 @@ TEST_F(UartDriverTest, Uart2WritePartialThenComplete)
 
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
 
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data1, FIRST_WRITE), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data1, FIRST_WRITE, &bytes_written), HAL_STATUS_OK);
 
     for (int i = 0; i < FIRST_WRITE / 2; i++) {
         Sim_USART2.SR |= USART_SR_TXE;
@@ -786,7 +799,7 @@ TEST_F(UartDriverTest, Uart2WritePartialThenComplete)
         ASSERT_EQ(Sim_USART2.DR, 'A');
     }
 
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data2, SECOND_WRITE), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data2, SECOND_WRITE, &bytes_written), HAL_STATUS_OK);
 
     for (int i = 0; i < (FIRST_WRITE / 2); i++) {
         Sim_USART2.SR |= USART_SR_TXE;
@@ -811,17 +824,18 @@ TEST_F(UartDriverTest, WriteDoesNotEnableTXEWhenBufferNotEmpty)
 {
     uint8_t data1[] = {'A'};
     uint8_t data2[] = {'B'};
+    size_t bytes_written = 0;
 
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
     // First write - should enable TXE
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data1, 1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data1, 1, &bytes_written), HAL_STATUS_OK);
     ASSERT_TRUE(Sim_USART1.CR1 & USART_CR1_TXEIE);
 
     // Second write while buffer not empty - should NOT re-enable TXE
     // (it's already enabled)
     Sim_USART1.CR1 &= ~USART_CR1_TXEIE; // Clear flag to test
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data2, 1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data2, 1, &bytes_written), HAL_STATUS_OK);
 
     // @todo reevaluate this requirement.
     // ASSERT_FALSE(Sim_USART1.CR1 & USART_CR1_TXEIE); // Should remain cleared
@@ -831,6 +845,7 @@ TEST_F(UartDriverTest, WriteHandlesRandomData)
 {
     const size_t DATA_LEN = 50;
     uint8_t data_sent[DATA_LEN];
+    size_t bytes_written = 0;
 
     // Generate random test data
     for (int i = 0; i < DATA_LEN; i++) {
@@ -838,7 +853,7 @@ TEST_F(UartDriverTest, WriteHandlesRandomData)
     }
 
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data_sent, DATA_LEN), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data_sent, DATA_LEN, &bytes_written), HAL_STATUS_OK);
 
     // Verify all random data transmits correctly
     for (int i = 0; i < DATA_LEN; i++) {
@@ -858,9 +873,10 @@ TEST_F(UartDriverTest, WriteHandlesSpecialByteValues)
 {
     uint8_t special_bytes[] = {0x00, 0xFF, 0x7F, 0x80, 0x55, 0xAA};
     size_t len = sizeof(special_bytes);
+    size_t bytes_written = 0;
 
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, special_bytes, len), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, special_bytes, len, &bytes_written), HAL_STATUS_OK);
 
     for (int i = 0; i < len; i++) {
         Sim_USART2.SR |= USART_SR_TXE;
@@ -873,11 +889,12 @@ TEST_F(UartDriverTest, WriteWithExcessiveLengthRequest)
 {
     const size_t HUGE_LEN = SIZE_MAX;
     uint8_t single_byte = 'X';
+    size_t bytes_written = 0;
 
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
     // Should fail gracefully - can't fit SIZE_MAX bytes in buffer
-    ASSERT_EQ(hal_uart_write(HAL_UART1, &single_byte, HUGE_LEN), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, &single_byte, HUGE_LEN, &bytes_written), HAL_STATUS_ERROR);
 
     // @todo reevaluate this requirement.
     // TXE interrupt should not be enabled
@@ -931,14 +948,17 @@ TEST_F(UartDriverTest, ReadFailsOnUninitializedUart)
 TEST_F(UartDriverTest, WriteFailsOnUninitializedUart)
 {
     uint8_t data[] = "test";
+    size_t bytes_written = 0;
 
     // Don't call hal_uart_init
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data, sizeof(data)-1), HAL_STATUS_ERROR);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data, sizeof(data)-1), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data, sizeof(data)-1, &bytes_written), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data, sizeof(data)-1, &bytes_written), HAL_STATUS_ERROR);
 }
 
 TEST_F(UartDriverTest, Uart1MultipleInitsFail)
 {
+    size_t bytes_written = 0;
+
     // First init should succeed
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
@@ -947,11 +967,13 @@ TEST_F(UartDriverTest, Uart1MultipleInitsFail)
 
     // Operations should still work after failed re-init
     uint8_t data[] = "test";
-    ASSERT_EQ(hal_uart_write(HAL_UART1, data, sizeof(data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, data, sizeof(data)-1, &bytes_written), HAL_STATUS_OK);
 }
 
 TEST_F(UartDriverTest, Uart2MultipleInitsFail)
 {
+    size_t bytes_written = 0;
+
     // First init should succeed
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
 
@@ -960,7 +982,7 @@ TEST_F(UartDriverTest, Uart2MultipleInitsFail)
 
     // Operations should still work after failed re-init
     uint8_t data[] = "test";
-    ASSERT_EQ(hal_uart_write(HAL_UART2, data, sizeof(data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, data, sizeof(data)-1, &bytes_written), HAL_STATUS_OK);
 }
 
 TEST_F(UartDriverTest, ReinitAfterDeinitSucceeds)
@@ -977,6 +999,8 @@ TEST_F(UartDriverTest, ReinitAfterDeinitSucceeds)
 
 TEST_F(UartDriverTest, Uart1DeinitRestoresHardwareToSafeState)
 {
+    size_t bytes_written = 0;
+
     // Initialize UART1 and verify it's configured correctly
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
@@ -991,7 +1015,7 @@ TEST_F(UartDriverTest, Uart1DeinitRestoresHardwareToSafeState)
 
     // Add some data to buffers to verify they get cleared
     uint8_t write_data[] = "test_data";
-    ASSERT_EQ(hal_uart_write(HAL_UART1, write_data, sizeof(write_data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, write_data, sizeof(write_data)-1, &bytes_written), HAL_STATUS_OK);
 
     // Simulate some received data
     Sim_USART1.DR = 'A';
@@ -1024,7 +1048,7 @@ TEST_F(UartDriverTest, Uart1DeinitRestoresHardwareToSafeState)
 
     ASSERT_EQ(hal_uart_read(HAL_UART1, read_data, sizeof(read_data), &bytes_read, 0),
               HAL_STATUS_ERROR);
-    ASSERT_EQ(hal_uart_write(HAL_UART1, more_write_data, sizeof(more_write_data)-1),
+    ASSERT_EQ(hal_uart_write(HAL_UART1, more_write_data, sizeof(more_write_data)-1, &bytes_written),
               HAL_STATUS_ERROR);
 
     // Multiple deints should be safe (idempotent)
@@ -1033,23 +1057,25 @@ TEST_F(UartDriverTest, Uart1DeinitRestoresHardwareToSafeState)
 
 TEST_F(UartDriverTest, DeinitDoesNotAffectOtherUARTs)
 {
+    size_t bytes_written = 0;
+
     // Initialize both UARTs
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
     ASSERT_EQ(hal_uart_init(HAL_UART2, nullptr), HAL_STATUS_OK);
 
     // Verify both are working
     uint8_t test_data[] = "test";
-    ASSERT_EQ(hal_uart_write(HAL_UART1, test_data, sizeof(test_data)-1), HAL_STATUS_OK);
-    ASSERT_EQ(hal_uart_write(HAL_UART2, test_data, sizeof(test_data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, test_data, sizeof(test_data)-1, &bytes_written), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, test_data, sizeof(test_data)-1, &bytes_written), HAL_STATUS_OK);
 
     // Deinit only UART1
     ASSERT_EQ(hal_uart_deinit(HAL_UART1), HAL_STATUS_OK);
 
     // UART1 should be disabled
-    ASSERT_EQ(hal_uart_write(HAL_UART1, test_data, sizeof(test_data)-1), HAL_STATUS_ERROR);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, test_data, sizeof(test_data)-1, &bytes_written), HAL_STATUS_ERROR);
 
     // UART2 should still work normally
-    ASSERT_EQ(hal_uart_write(HAL_UART2, test_data, sizeof(test_data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART2, test_data, sizeof(test_data)-1, &bytes_written), HAL_STATUS_OK);
 
     // UART2 hardware should be unaffected
     ASSERT_TRUE(Sim_USART2.CR1 & USART_CR1_UE);              // UART2 still enabled
@@ -1059,11 +1085,13 @@ TEST_F(UartDriverTest, DeinitDoesNotAffectOtherUARTs)
 
 TEST_F(UartDriverTest, ReinitAfterDeinitRestoresFullFunctionality)
 {
+    size_t bytes_written = 0;
+
     // Initial setup and operation
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
     uint8_t original_data[] = "original";
-    ASSERT_EQ(hal_uart_write(HAL_UART1, original_data, sizeof(original_data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, original_data, sizeof(original_data)-1, &bytes_written), HAL_STATUS_OK);
 
     // Deinit
     ASSERT_EQ(hal_uart_deinit(HAL_UART1), HAL_STATUS_OK);
@@ -1081,7 +1109,7 @@ TEST_F(UartDriverTest, ReinitAfterDeinitRestoresFullFunctionality)
 
     // Verify functionality is restored
     uint8_t new_data[] = "reinit_test";
-    ASSERT_EQ(hal_uart_write(HAL_UART1, new_data, sizeof(new_data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, new_data, sizeof(new_data)-1, &bytes_written), HAL_STATUS_OK);
 
     // Verify read functionality
     Sim_USART1.DR = 'R';
@@ -1097,11 +1125,13 @@ TEST_F(UartDriverTest, ReinitAfterDeinitRestoresFullFunctionality)
 
 TEST_F(UartDriverTest, DeinitClearsBufferState)
 {
+    size_t bytes_written = 0;
+
     ASSERT_EQ(hal_uart_init(HAL_UART1, nullptr), HAL_STATUS_OK);
 
     // Fill buffers with data
     uint8_t write_data[] = "buffer_data";
-    ASSERT_EQ(hal_uart_write(HAL_UART1, write_data, sizeof(write_data)-1), HAL_STATUS_OK);
+    ASSERT_EQ(hal_uart_write(HAL_UART1, write_data, sizeof(write_data)-1, &bytes_written), HAL_STATUS_OK);
 
     // Add received data
     for (int i = 0; i < 10; i++) {

--- a/test/main.c
+++ b/test/main.c
@@ -28,6 +28,9 @@ int main(void)
 		bytes_read_uart1 = 0;
 		bytes_read_uart2 = 0;
 
+		bytes_written_uart1 = 0;
+		bytes_written_uart2 = 0;
+
 		memset(rx_data_uart1, 0, sizeof(rx_data_uart1));
 		memset(rx_data_uart2, 0, sizeof(rx_data_uart2));
 

--- a/test/main.c
+++ b/test/main.c
@@ -11,6 +11,10 @@ int main(void)
 {
 	size_t bytes_read_uart1 = 0;
 	size_t bytes_read_uart2 = 0;
+
+	size_t bytes_written_uart1 = 0;
+	size_t bytes_written_uart2 = 0;
+
 	uint8_t rx_data_uart1[MAX_RX_BYTES] = { 0 };
 	uint8_t rx_data_uart2[MAX_RX_BYTES] = { 0 };
 
@@ -23,6 +27,7 @@ int main(void)
 		// Reset all data structures.
 		bytes_read_uart1 = 0;
 		bytes_read_uart2 = 0;
+
 		memset(rx_data_uart1, 0, sizeof(rx_data_uart1));
 		memset(rx_data_uart2, 0, sizeof(rx_data_uart2));
 
@@ -31,8 +36,8 @@ int main(void)
 		hal_uart_read(HAL_UART2, &rx_data_uart2[0], sizeof(rx_data_uart2), &bytes_read_uart2, 0);
 
 		// Echo the data back to sender.
-		hal_uart_write(HAL_UART1, &rx_data_uart1[0], bytes_read_uart1);
-		hal_uart_write(HAL_UART2, &rx_data_uart2[0], bytes_read_uart2);
+		hal_uart_write(HAL_UART1, &rx_data_uart1[0], bytes_read_uart1, &bytes_written_uart1);
+		hal_uart_write(HAL_UART2, &rx_data_uart2[0], bytes_read_uart2, &bytes_written_uart2);
 	}
 
 	return 0;


### PR DESCRIPTION
## Context
After changing the uart driver's write() function to allow for tighter critical sections in #9, the signature of write() needed to change to reflect the new behavior. Previously, write() would guarantee that the data would fit by checking the available buffer space first, and if there was enough space, write the message in entirety. Now, write() begins writing right away, leaving the possibility that some bytes from data are passed into the buffer, while others aren't. The caller needs a way to know how many bytes were actually written to the buffer.

## Changes
- Added `bytes_written` parameter to all `hal_uart_write()` functions.
- Modified code and tests to call appropriately.
- Modified tests to take advantage of `bytes_written`