### PR TITLE
NE-48: Enable FPU for MCU

### DIFF
--- a/cmake/toolchain/CMakeToolChain.stm32f446.cmake
+++ b/cmake/toolchain/CMakeToolChain.stm32f446.cmake
@@ -18,6 +18,7 @@ set(CMAKE_EXE_LINKER_FLAGS "-mcpu=cortex-m4 -T${PROJECT_SOURCE_DIR}/platforms/st
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --specs=nosys.specs -Wl,-Map=\"jays_uart.map\"")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections -static -mfpu=fpv4-sp-d16 -mfloat-abi=hard -mthumb")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--start-group -lc -lm -Wl,--end-group")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -u _printf_float")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/hal_interface/include/hal_system.h
+++ b/hal_interface/include/hal_system.h
@@ -1,0 +1,6 @@
+#ifndef _HAL_SYSTEM_H
+#define _HAL_SYSTEM_H
+
+void hal_system_init();
+
+#endif /* _HAL_SYSTEM_H */

--- a/platforms/stm32f446re/hal/CMakeLists.txt
+++ b/platforms/stm32f446re/hal/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
     stm32f4_hal
     stm32f4_gpio.c
     stm32f4_systick.c
+    system/stm32f4_hal_system.c
     uart/src/stm32f4_uart.c
     uart/src/stm32f4_uart1.c
     uart/src/stm32f4_uart2.c

--- a/platforms/stm32f446re/hal/system/stm32f4_hal_system.c
+++ b/platforms/stm32f446re/hal/system/stm32f4_hal_system.c
@@ -1,0 +1,22 @@
+#include "hal_system.h"
+#include "stm32f4xx.h"
+
+// Coprocessor full access enables full use of the Floating Point Unit (FPU).
+#define CP_FULL_ACCESS 3UL
+
+// Bit locations for coprocessors 10 and 11 in the CPACR register of the
+// System Control Block (SCB).
+#define CP10 20
+#define CP11 22
+
+void hal_system_init()
+{
+    SystemInit();
+}
+
+void SystemInit(void)
+{
+    // Give CP10 & CP11 full access (FPU)
+    SCB->CPACR |= (CP_FULL_ACCESS << CP10) | (CP_FULL_ACCESS << CP11);
+    __DSB(); __ISB();  // complete prior writes & flush pipeline
+}

--- a/platforms/stm32f446re/hal/system/stm32f4_hal_system.c
+++ b/platforms/stm32f446re/hal/system/stm32f4_hal_system.c
@@ -1,5 +1,4 @@
 #include "hal_system.h"
-#include "stm32f4xx.h"
 
 // Coprocessor full access enables full use of the Floating Point Unit (FPU).
 #define CP_FULL_ACCESS 3UL
@@ -9,14 +8,26 @@
 #define CP10 20
 #define CP11 22
 
-void hal_system_init()
+#ifdef SIMULATION_BUILD
+
+void SystemInit(void)
 {
-    SystemInit();
+    return;
 }
+
+#else
+#include "stm32f4xx.h"
 
 void SystemInit(void)
 {
     // Give CP10 & CP11 full access (FPU)
     SCB->CPACR |= (CP_FULL_ACCESS << CP10) | (CP_FULL_ACCESS << CP11);
     __DSB(); __ISB();  // complete prior writes & flush pipeline
+}
+
+#endif
+
+void hal_system_init()
+{
+    SystemInit();
 }


### PR DESCRIPTION
## Context
The STM32F4 needs the Floating Point Unit Coprocessor to be enabled by software in order to allow floating point instructions to be executed. Otherwise, NOCP is thrown and the MCU ends up in a Hard Fault Handler.

## Changes
Adds a `hal_system_init()` function to bring up coprocessors. Must be called early in main. Adds a flag to tell linker to link to printf version that can handle floats, so printing them over serial is possible.