### PR TITLE
NE-49: I2C Transaction Queue Unit Tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,5 +23,21 @@
             // Add LD_LIBRARY_PATH etc. here if your test exe needs it
             ]
         },
+        {
+            "name": "Desktop Unit Tests: i2c_driver_test",
+            "type": "cppdbg",                 // use "cppvsdbg" if you’re on MSVC/Windows
+            "request": "launch",
+            "program": "${workspaceRoot}/build/desktop-debug/simulations/stm32f446re/i2c_driver_test",
+            //   "program": "${command:cmake.launchTargetPath}",  // auto-filled by CMake Tools
+            "cwd": "${workspaceFolder}",
+            "MIMode": "gdb",                  // or "lldb" / "gdb"
+            "stopAtEntry": false,
+            //   "preLaunchTask": "build-desktop", // see sample task below
+            "externalConsole": false,
+            "args": ["--gtest_filter=*"],     // run all tests; change as you like
+            "environment": [
+            // Add LD_LIBRARY_PATH etc. here if your test exe needs it
+            ]
+        },
     ],
 }

--- a/platforms/stm32f446re/hal/i2c/include/i2c_transaction_queue.h
+++ b/platforms/stm32f446re/hal/i2c/include/i2c_transaction_queue.h
@@ -1,5 +1,21 @@
+/**
+ * @file i2c_transaction_queue.h
+ *
+ * @brief FIFO data structure used to store handles to client I2C transaction requests.
+ *
+ * @note Clients are responsible for owning the memory for their transactions. This
+ * queue only holds handles to the transactions so they may be processed in order.
+ *
+ * @warning Undefined behavior will occur if the transaction added to queue was
+ * located on a function's call stack that then returns.
+ */
 #include "i2c.h"
 
+// Determines the maximum number of transaction requests
+// that can be queued simultaneously.
+#define I2C_TRANSACTION_QUEUE_SIZE 10
+
+// Return type indicating the result of the requested queue operation.
 typedef enum {
     _I2C_QUEUE_STATUS_ENUM_MIN = 0,
     I2C_QUEUE_STATUS_SUCCESS = _I2C_QUEUE_STATUS_ENUM_MIN,
@@ -9,5 +25,36 @@ typedef enum {
     _I2C_QUEUE_STATUS_ENUM_MAX,
 } i2c_queue_status_t;
 
-i2c_queue_status_t i2c_add_transaction_to_queue(HalI2C_Txn_t *txn);
-i2c_queue_status_t i2c_get_next_transaction_from_queue(HalI2C_Txn_t **txn);
+/**
+ * @brief Add a transaction to the queue.
+ *
+ * @param txn A reference to the tranaction to queue.
+ *
+ * @warning Clients are responsible for maintaining the memory for
+ * their transactions. This merely queues a handle.
+ *
+ * @return The status of the request. SUCCESS is the only return value indicating
+ * the request was queued.
+ */
+i2c_queue_status_t i2c_transaction_queue_add(HalI2C_Txn_t *txn);
+
+/**
+ * @brief Get the next transaction from the queue. Removes the transaction from the queue.
+ *
+ * @param txn A reference to a handle type for a transaction.
+ *
+ * @note txn is a double pointer because the client is meant to pass in a null handle that
+ * they want set to point to the next transaction to process. But to actually set a param,
+ * there needs to be a reference to it, hence, the double pointer.
+ *
+ * @return The status of the request. SUCCESS is the only return value indicating
+ * the next transaction was properly dequeued.
+ */
+i2c_queue_status_t i2c_transaction_queue_get_next(HalI2C_Txn_t **txn);
+
+/**
+ * @brief Resets the queue.
+ *
+ * It resets all internal variables that manage the queue so it will be "like new".
+ */
+void i2c_transaction_queue_reset();

--- a/platforms/stm32f446re/hal/i2c/src/i2c_transaction_queue.c
+++ b/platforms/stm32f446re/hal/i2c/src/i2c_transaction_queue.c
@@ -1,7 +1,5 @@
 #include "i2c_transaction_queue.h"
 
-#define I2C_TRANSACTION_QUEUE_SIZE 10
-
 typedef struct {
     HalI2C_Txn_t *transactions[I2C_TRANSACTION_QUEUE_SIZE];
     size_t head;
@@ -15,7 +13,7 @@ static i2c_transaction_queue_t queue = {
     .transaction_count = 0
 };
 
-i2c_queue_status_t i2c_add_transaction_to_queue(HalI2C_Txn_t *txn)
+i2c_queue_status_t i2c_transaction_queue_add(HalI2C_Txn_t *txn)
 {
     i2c_queue_status_t status = I2C_QUEUE_STATUS_FAIL;
 
@@ -47,7 +45,7 @@ i2c_queue_status_t i2c_add_transaction_to_queue(HalI2C_Txn_t *txn)
 // The desire is to actually set the pointer passed to this function, and to set
 // a parameter, there needs to be a reference. In conclusion, this is a reference to
 // a pointer type.
-i2c_queue_status_t i2c_get_next_transaction_from_queue(HalI2C_Txn_t **txn)
+i2c_queue_status_t i2c_transaction_queue_get_next(HalI2C_Txn_t **txn)
 {
     i2c_queue_status_t status = I2C_QUEUE_STATUS_FAIL;
 
@@ -67,4 +65,11 @@ i2c_queue_status_t i2c_get_next_transaction_from_queue(HalI2C_Txn_t **txn)
     }
 
     return status;
+}
+
+void i2c_transaction_queue_reset()
+{
+    queue.head = 0;
+    queue.tail = 0;
+    queue.transaction_count = 0;
 }

--- a/platforms/stm32f446re/hal/i2c/src/stm32f4_i2c.c
+++ b/platforms/stm32f446re/hal/i2c/src/stm32f4_i2c.c
@@ -231,7 +231,7 @@ HalStatus_t hal_i2c_deinit(void)
 HalStatus_t hal_i2c_submit_transaction(HalI2C_Txn_t *txn)
 {
     // @todo: Some transaction validation here.
-    return (i2c_add_transaction_to_queue(txn) == I2C_QUEUE_STATUS_SUCCESS) ? HAL_STATUS_OK : HAL_STATUS_ERROR;
+    return (i2c_transaction_queue_add(txn) == I2C_QUEUE_STATUS_SUCCESS) ? HAL_STATUS_OK : HAL_STATUS_ERROR;
 }
 
 HalStatus_t hal_i2c_transaction_servicer()
@@ -262,7 +262,7 @@ HalStatus_t hal_i2c_transaction_servicer()
         }
 
         // Load in a new transaction if there is one.
-        if (I2C_QUEUE_STATUS_SUCCESS == i2c_get_next_transaction_from_queue(&current_i2c_transaction) &&
+        if (I2C_QUEUE_STATUS_SUCCESS == i2c_transaction_queue_get_next(&current_i2c_transaction) &&
             current_i2c_transaction)
         {
             // Set state to processing.

--- a/simulations/stm32f446re/CMakeLists.txt
+++ b/simulations/stm32f446re/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(
 add_executable(
     i2c_driver_test
     test/i2c_driver_test.cpp
+    test/i2c_transaction_queue_test.cpp
     test/main.cpp
 )
 

--- a/simulations/stm32f446re/stm32f4_mocks/include/nvic.h
+++ b/simulations/stm32f446re/stm32f4_mocks/include/nvic.h
@@ -8,6 +8,9 @@ extern "C" {
 #define USART2_IRQn 38
 #define USART1_IRQn 37
 
+#define I2C1_EV_IRQn 31
+#define I2C1_ER_IRQn 32
+
 void NVIC_EnableIRQ(size_t interrupt_number);
 bool NVIC_IsIRQEnabled(size_t interrupt_number);
 void NVIC_DisableIRQ(size_t interrupt_number);

--- a/simulations/stm32f446re/stm32f4_mocks/src/nvic.c
+++ b/simulations/stm32f446re/stm32f4_mocks/src/nvic.c
@@ -1,7 +1,11 @@
 #include "nvic.h"
 
+// @todo make this an array of bools indexed by IRQn
+// if there is need for more.
 static bool uart1_isr_enabled = false;
 static bool uart2_isr_enabled = false;
+static bool i2c1_ev_isr_enabled = false;
+static bool i2c1_er_isr_enabled = false;
 
 void NVIC_EnableIRQ(size_t interrupt_number)
 {
@@ -12,6 +16,14 @@ void NVIC_EnableIRQ(size_t interrupt_number)
     else if (interrupt_number == USART2_IRQn)
     {
         uart2_isr_enabled = true;
+    }
+    else if (interrupt_number == I2C1_EV_IRQn)
+    {
+        i2c1_ev_isr_enabled = true;
+    }
+    else if (interrupt_number == I2C1_ER_IRQn)
+    {
+        i2c1_er_isr_enabled = true;
     }
 }
 
@@ -27,6 +39,14 @@ bool NVIC_IsIRQEnabled(size_t interrupt_number)
     {
         res = uart2_isr_enabled;
     }
+    else if (interrupt_number == I2C1_EV_IRQn)
+    {
+        res = i2c1_ev_isr_enabled;
+    }
+    else if (interrupt_number == I2C1_ER_IRQn)
+    {
+        res = i2c1_er_isr_enabled;
+    }
 
     return res;
 }
@@ -40,5 +60,13 @@ void NVIC_DisableIRQ(size_t interrupt_number)
     else if (interrupt_number == USART2_IRQn)
     {
         uart2_isr_enabled = false;
+    }
+    else if (interrupt_number == I2C1_EV_IRQn)
+    {
+        i2c1_ev_isr_enabled = false;
+    }
+    else if (interrupt_number == I2C1_ER_IRQn)
+    {
+        i2c1_er_isr_enabled = false;
     }
 }

--- a/simulations/stm32f446re/test/i2c_driver_test.cpp
+++ b/simulations/stm32f446re/test/i2c_driver_test.cpp
@@ -23,6 +23,7 @@ protected:
         // @todo Sim I2C
         Sim_GPIOB = {0};
         Sim_RCC = {0};
+        Sim_I2C1 = {0};
 
         // Set up the seed only once per full testing run.
         // if (!seed_is_set) {
@@ -89,4 +90,21 @@ TEST_F(I2CDriverTest, InitsPeripheralCorrectly)
 
     // Peripheral is enabled
     ASSERT_TRUE(Sim_I2C1.CR1 & I2C_CR1_PE);
+}
+
+TEST_F(I2CDriverTest, InitsInterruptsCorrectly)
+{
+    ASSERT_EQ(hal_i2c_init(nullptr), HAL_STATUS_OK);
+
+    // Event interrupt enabled in peripheral
+    ASSERT_TRUE(Sim_I2C1.CR2 & I2C_CR2_ITEVTEN);
+
+    // Error interrupt enabled in peripheral
+    ASSERT_TRUE(Sim_I2C1.CR2 & I2C_CR2_ITERREN);
+
+    // Event interrupt enabled in NVIC
+    ASSERT_TRUE(NVIC_IsIRQEnabled(I2C1_EV_IRQn));
+
+    // Error interrupt enabled in NVIC
+    ASSERT_TRUE(NVIC_IsIRQEnabled(I2C1_ER_IRQn));
 }

--- a/simulations/stm32f446re/test/i2c_transaction_queue_test.cpp
+++ b/simulations/stm32f446re/test/i2c_transaction_queue_test.cpp
@@ -109,23 +109,24 @@ TEST_F(I2CTransactionQueueTest, QueueAddMarksTransactionAsQueued)
 
 TEST_F(I2CTransactionQueueTest, QueueHandlesRollover)
 {
-    const size_t NUM_OF_TRANSACTIONS = 510; // Divisible by 6.
+    const size_t ROLLOVER_INCREMENT = (I2C_TRANSACTION_QUEUE_SIZE / 2) + 1;
+    const size_t NUM_OF_TRANSACTIONS = 100 * ROLLOVER_INCREMENT; // Divisible by ROLLOVER_INCREMENT.
     size_t transaction_in_index = 0;
     size_t transaction_out_index = 0;
-    HalI2C_Txn_t transactions_in[NUM_OF_TRANSACTIONS];
+    static HalI2C_Txn_t transactions_in[NUM_OF_TRANSACTIONS]; // Static because this data structure can be too large for the stack.
     HalI2C_Txn_t *transaction_out = nullptr;
 
     // Conduct the rollover test.
-    for (size_t i = 0; i < NUM_OF_TRANSACTIONS / 6; i++)
+    for (size_t i = 0; i < NUM_OF_TRANSACTIONS / ROLLOVER_INCREMENT; i++)
     {
-        // Queue 6
-        for (size_t j = 0; j < 6; j++)
+        // Queue ROLLOVER_INCREMENT number of transactions.
+        for (size_t j = 0; j < ROLLOVER_INCREMENT; j++)
         {
             ASSERT_EQ(i2c_transaction_queue_add(&transactions_in[transaction_in_index++]), I2C_QUEUE_STATUS_SUCCESS);
         }
 
-        // Dequeue 6
-        for (size_t j = 0; j < 6; j++)
+        // Dequeue ROLLOVER_INCREMENT number of transactions.
+        for (size_t j = 0; j < ROLLOVER_INCREMENT; j++)
         {
             // Make sure we can dequeue.
             ASSERT_EQ(i2c_transaction_queue_get_next(&transaction_out), I2C_QUEUE_STATUS_SUCCESS);

--- a/simulations/stm32f446re/test/i2c_transaction_queue_test.cpp
+++ b/simulations/stm32f446re/test/i2c_transaction_queue_test.cpp
@@ -1,0 +1,181 @@
+#include "gtest/gtest.h"
+
+extern "C" {
+    #include "i2c_transaction_queue.h"
+}
+
+class I2CTransactionQueueTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            i2c_transaction_queue_reset();
+        }
+
+        void TearDown() override {
+
+        }
+};
+
+TEST_F(I2CTransactionQueueTest, QueueAddRejectsNull)
+{
+    ASSERT_EQ(i2c_transaction_queue_add(nullptr), I2C_QUEUE_STATUS_FAIL);
+}
+
+TEST_F(I2CTransactionQueueTest, QueueNextRejectsNull)
+{
+    ASSERT_EQ(i2c_transaction_queue_get_next(nullptr), I2C_QUEUE_STATUS_FAIL);
+}
+
+TEST_F(I2CTransactionQueueTest, BasicPushPop)
+{
+    // The transaction to queue.
+    HalI2C_Txn_t txn_in = {
+        .i2c_op = HAL_I2C_OP_WRITE_READ, // Only init this.
+    };
+
+    // The handle the dequeuer would receive.
+    HalI2C_Txn_t *txn_out = nullptr;
+
+    // Assert we can add the transaction to the queue.
+    ASSERT_EQ(i2c_transaction_queue_add(&txn_in), I2C_QUEUE_STATUS_SUCCESS);
+
+    // Assert we can grab it from the queue.
+    ASSERT_EQ(i2c_transaction_queue_get_next(&txn_out), I2C_QUEUE_STATUS_SUCCESS);
+
+    // Assert our handle is no longer NULL.
+    ASSERT_NE(txn_out, nullptr);
+
+    // Assert that our data is there.
+    ASSERT_EQ(txn_out->i2c_op, HAL_I2C_OP_WRITE_READ);
+
+    // Assert we are pointing to the correct data.
+    ASSERT_EQ(txn_out, &txn_in);
+}
+
+TEST_F(I2CTransactionQueueTest, ReturnsQueueFullStatus)
+{
+    // Define one more transaction than can fit in the queue.
+    HalI2C_Txn_t transactions[I2C_TRANSACTION_QUEUE_SIZE + 1];
+
+    // Fill the queue.
+    for (int i = 0; i < I2C_TRANSACTION_QUEUE_SIZE; i++)
+    {
+        ASSERT_EQ(i2c_transaction_queue_add(&transactions[i]), I2C_QUEUE_STATUS_SUCCESS);
+    }
+
+    // Expect the next transaction to return QUEUE FULL
+    ASSERT_EQ(i2c_transaction_queue_add(&transactions[I2C_TRANSACTION_QUEUE_SIZE]), I2C_QUEUE_STATUS_QUEUE_FULL);
+}
+
+TEST_F(I2CTransactionQueueTest, ReturnsQueueEmptyStatus)
+{
+    HalI2C_Txn_t *txn_out = nullptr;
+
+    // Assert the queue is empty.
+    ASSERT_EQ(i2c_transaction_queue_get_next(&txn_out), I2C_QUEUE_STATUS_QUEUE_EMPTY);
+}
+
+TEST_F(I2CTransactionQueueTest, QueueCanBeReset)
+{
+    HalI2C_Txn_t *txn_out = nullptr;
+    HalI2C_Txn_t transactions[I2C_TRANSACTION_QUEUE_SIZE];
+
+    // Add a couple transactions.
+    for (int i = 0; i < 3 && i < I2C_TRANSACTION_QUEUE_SIZE; i++)
+    {
+        ASSERT_EQ(i2c_transaction_queue_add(&transactions[i]), I2C_QUEUE_STATUS_SUCCESS);
+    }
+
+    // Reset the queue.
+    i2c_transaction_queue_reset();
+
+    // Assert the queue is empty.
+    ASSERT_EQ(i2c_transaction_queue_get_next(&txn_out), I2C_QUEUE_STATUS_QUEUE_EMPTY);
+
+    // Assert txn_out is still null.
+    ASSERT_EQ(txn_out, nullptr);
+}
+
+TEST_F(I2CTransactionQueueTest, QueueAddMarksTransactionAsQueued)
+{
+    // Setup
+    HalI2C_Txn_t txn_in = {
+        .processing_state = HAL_I2C_TXN_STATE_CREATED, // init the processing state to CREATED.
+    };
+    ASSERT_EQ(i2c_transaction_queue_add(&txn_in), I2C_QUEUE_STATUS_SUCCESS);
+
+    // Assert the processing state is now QUEUED.
+    ASSERT_EQ(txn_in.processing_state, HAL_I2C_TXN_STATE_QUEUED);
+}
+
+TEST_F(I2CTransactionQueueTest, QueueHandlesRollover)
+{
+    const size_t NUM_OF_TRANSACTIONS = 510; // Divisible by 6.
+    size_t transaction_in_index = 0;
+    size_t transaction_out_index = 0;
+    HalI2C_Txn_t transactions_in[NUM_OF_TRANSACTIONS];
+    HalI2C_Txn_t *transaction_out = nullptr;
+
+    // Conduct the rollover test.
+    for (size_t i = 0; i < NUM_OF_TRANSACTIONS / 6; i++)
+    {
+        // Queue 6
+        for (size_t j = 0; j < 6; j++)
+        {
+            ASSERT_EQ(i2c_transaction_queue_add(&transactions_in[transaction_in_index++]), I2C_QUEUE_STATUS_SUCCESS);
+        }
+
+        // Dequeue 6
+        for (size_t j = 0; j < 6; j++)
+        {
+            // Make sure we can dequeue.
+            ASSERT_EQ(i2c_transaction_queue_get_next(&transaction_out), I2C_QUEUE_STATUS_SUCCESS);
+
+            // Assert that what we got out is what we put in and in the correct order.
+            ASSERT_EQ(&transactions_in[transaction_out_index++], transaction_out);
+
+            transaction_out = nullptr;
+        }
+
+        // Make sure these stay synced after queue/dequeue cycles.
+        ASSERT_EQ(transaction_in_index, transaction_out_index);
+    }
+}
+
+TEST_F(I2CTransactionQueueTest, NoFieldsAreUnexpectedlyModifiedByQueue)
+{
+    HalI2C_Txn_t *my_transaction_ptr = nullptr;
+    HalI2C_Txn_t my_transaction = {
+        // Immutable once submitted.
+        .target_addr = 0x58,
+        .i2c_op = HAL_I2C_OP_WRITE_READ,
+        .tx_data = { 0x23 },
+        .num_of_bytes_to_tx = 1,
+        .expected_bytes_to_rx = 1,
+
+        // Poll to determine completion status.
+        .processing_state = HAL_I2C_TXN_STATE_CREATED,
+
+        // Post transaction completion results.
+        .transaction_result = HAL_I2C_TXN_RESULT_NONE,
+        .actual_bytes_received = 0,
+        .actual_bytes_transmitted = 0,
+        .rx_data = {0},
+    };
+
+    // Send the transaction through the queue.
+    ASSERT_EQ(i2c_transaction_queue_add(&my_transaction), I2C_QUEUE_STATUS_SUCCESS);
+    ASSERT_EQ(i2c_transaction_queue_get_next(&my_transaction_ptr), I2C_QUEUE_STATUS_SUCCESS);
+    ASSERT_EQ(&my_transaction, my_transaction_ptr);
+
+    // Verify nothing was unexpectedly modified.
+    ASSERT_EQ(my_transaction.target_addr, 0x58);
+    ASSERT_EQ(my_transaction.i2c_op, HAL_I2C_OP_WRITE_READ);
+    ASSERT_EQ(my_transaction.tx_data[0], 0x23);
+    ASSERT_EQ(my_transaction.num_of_bytes_to_tx, 1);
+    ASSERT_EQ(my_transaction.expected_bytes_to_rx, 1);
+    ASSERT_EQ(my_transaction.processing_state, HAL_I2C_TXN_STATE_QUEUED); // Only one that mutates.
+    ASSERT_EQ(my_transaction.transaction_result, HAL_I2C_TXN_RESULT_NONE);
+    ASSERT_EQ(my_transaction.actual_bytes_received, 0);
+    ASSERT_EQ(my_transaction.actual_bytes_transmitted, 0);
+    ASSERT_EQ(my_transaction.rx_data[0], 0);
+}


### PR DESCRIPTION
## Context
The feature was merged ahead of the unit tests. This PR exists to back-fill those tests and lock in the feature behavior.

## Changes
- Cleans up the interface of transaction queue and adds documentation.
- Adds unit tests to cover major functionality and edge cases of I2C Transaction Queue.
- Adds desktop debug configuration for I2C driver.